### PR TITLE
Allow AbstractVectors

### DIFF
--- a/.lh/src/sorttwo!.jl.json
+++ b/.lh/src/sorttwo!.jl.json
@@ -1,0 +1,18 @@
+{
+    "sourceFile": "src/sorttwo!.jl",
+    "activeCommit": 0,
+    "commits": [
+        {
+            "activePatchIndex": 0,
+            "patches": [
+                {
+                    "date": 1626746187070,
+                    "content": "Index: \n===================================================================\n--- \n+++ \n"
+                }
+            ],
+            "date": 1626746187070,
+            "name": "Commit-0",
+            "content": "import StatsBase: BaseRadixSortSafeTypes\n\n\"\"\"\n    sorttwo!(vs, index)\n\nSort both the `vs` and reorder `index` at the same. This allows for faster sortperm\nfor radix sort.\n\"\"\"\nfunction sorttwo!(vs::AbstractVector{T}, index, lo::Int = 1, hi::Int=length(vs), RADIX_SIZE = 16, RADIX_MASK = 0xffff) where T # <:Union{BaseRadixSortSafeTypes}\n    # Input checking\n    if lo >= hi;  return (vs, index);  end\n    #println(vs)\n    o = Forward\n\n    # Init\n    iters = ceil(Integer, sizeof(T)*8/RADIX_SIZE)\n    # number of buckets in the counting steuint_histp\n    nbuckets = 2^RADIX_SIZE\n\n    # Histogram for each element, radix\n    bin = uint_hist(vs, RADIX_SIZE, RADIX_MASK)\n\n    # bin = zeros(UInt32, nbuckets, iters)\n    # if lo > 1;  bin[1,:] = lo-1;  end\n\n    # Sort!\n    swaps = 0\n    len = hi-lo+1\n\n    index1 = similar(index)\n    ts=similar(vs)\n    for j = 1:iters\n        # Unroll first data iteration, check for degenerate case\n        v = uint_mapping(o, vs[hi])\n        idx = Int((v >> ((j-1)*RADIX_SIZE)) & RADIX_MASK) + 1\n\n        # are all values the same at this radix?\n        if bin[idx,j] == len;  continue;  end\n\n        # cbin = cumsum(bin[:,j])\n        # tries to achieve the above one-liner with more efficiency\n        cbin = zeros(UInt32, nbuckets)\n        cbin[1] = bin[1,j]\n        @inbounds for i in 2:nbuckets\n            cbin[i] = cbin[i-1] + bin[i,j]\n        end\n\n        ci = cbin[idx]\n        #println((ci, hi))\n        ts[ci] = vs[hi]\n        index1[ci] = index[hi]\n        # println(cbin[idx])\n        cbin[idx] -= 1\n\n        # Finish the loop...        \n        @inbounds for i in hi-1:-1:lo\n            v = uint_mapping(o, vs[i])\n            idx = Int((v >> ((j-1)*RADIX_SIZE)) & RADIX_MASK) + 1\n            ci = cbin[idx]\n            #println(ci)\n            ts[ci] = vs[i]\n            index1[ci] = index[i]\n            cbin[idx] -= 1\n        end\n        vs,ts = ts,vs\n        index, index1 = index1, index\n        swaps += 1\n    end\n\n    if isodd(swaps)\n        vs,ts = ts,vs\n        index, index1 = index1, index\n        for i = lo:hi\n            @inbounds vs[i] = ts[i]\n            @inbounds index[i] = index1[i]\n        end\n    end\n    (vs, index)\nend\n"
+        }
+    ]
+}

--- a/src/fsort.jl
+++ b/src/fsort.jl
@@ -66,5 +66,5 @@
 
 export fsort, fsort!
 
-fsort(x::Vector{T}; rev = false) where T <:BaseRadixSortSafeTypes = sort(x, alg = RadixSort; rev = rev)
-fsort!(x::Vector{T}; rev = false) where T <:BaseRadixSortSafeTypes = sort!(x, alg = RadixSort; rev = rev)
+fsort(x::AbstractVector{T}; rev = false) where T <:BaseRadixSortSafeTypes = sort(x, alg = RadixSort; rev = rev)
+fsort!(x::AbstractVector{T}; rev = false) where T <:BaseRadixSortSafeTypes = sort!(x, alg = RadixSort; rev = rev)

--- a/src/fsortperm_Integer.jl
+++ b/src/fsortperm_Integer.jl
@@ -190,7 +190,7 @@ end
 # based on sortperm_int_range_p1
 # see https://discourse.julialang.org/t/ironic-observation-about-sort-and-sortperm-speed-for-small-intergers-vs-r/8715/31?u=xiaodai
 ################################################################################
-function fsortperm_int_range_lsd(a::Vector{T}, rangelen, minval, RADIX_SIZE; rev = false) where T
+function fsortperm_int_range_lsd(a::AbstractVector{T}, rangelen, minval, RADIX_SIZE; rev = false) where T
     # println(RADIX_SIZE," ", now())
     # @assert 2^32 > rangelen
     # @assert 2^32 >= length(a)
@@ -211,7 +211,7 @@ function fsortperm_int_range_lsd(a::Vector{T}, rangelen, minval, RADIX_SIZE; rev
     [Int(vs1.first) for vs1 in vs]
 end
 
-function fsortandperm_int_range_lsd(a::Vector{T}, rangelen, minval, RADIX_SIZE; rev = false) where T
+function fsortandperm_int_range_lsd(a::AbstractVector{T}, rangelen, minval, RADIX_SIZE; rev = false) where T
     vs = Vector{Pair{UInt32, T}}(length(a))
     if rev
         maxval = maximum(a)

--- a/src/radixsort-StrFs.jl
+++ b/src/radixsort-StrFs.jl
@@ -15,7 +15,7 @@ SortingAlgorithms.uint_mapping(::Base.Order.ForwardOrdering, s::StrF{S}) where S
     ((res << (8*(16-sizeof(s)))) >> (8*(16-sizeof(s)))) |> ntoh
 end
 
-radixsort(v::Vector{StrF{S}}; rev = false) where S = begin
+radixsort(v::AbstractVector{StrF{S}}; rev = false) where S = begin
     if S <=16
         return sort(v, alg = RadixSort, rev = rev)
     else
@@ -23,7 +23,7 @@ radixsort(v::Vector{StrF{S}}; rev = false) where S = begin
     end
 end
 
-radixsort!(v::Vector{StrF{S}}; rev = false) where S = begin
+radixsort!(v::AbstractVector{StrF{S}}; rev = false) where S = begin
     if S <=16
         return sort!(v, alg = RadixSort, rev = rev)
     else

--- a/src/sorttwo!.jl
+++ b/src/sorttwo!.jl
@@ -6,7 +6,7 @@ import StatsBase: BaseRadixSortSafeTypes
 Sort both the `vs` and reorder `index` at the same. This allows for faster sortperm
 for radix sort.
 """
-function sorttwo!(vs::AbstractVector{T}, index=1:length(vs), lo::Int = 1, hi::Int=length(vs), RADIX_SIZE = 16, RADIX_MASK = 0xffff) where T # <:Union{BaseRadixSortSafeTypes}
+function sorttwo!(vs::AbstractVector{T}, index, lo::Int = 1, hi::Int=length(vs), RADIX_SIZE = 16, RADIX_MASK = 0xffff) where T # <:Union{BaseRadixSortSafeTypes}
     # Input checking
     if lo >= hi;  return (vs, index);  end
     #println(vs)

--- a/src/sorttwo!.jl
+++ b/src/sorttwo!.jl
@@ -6,7 +6,7 @@ import StatsBase: BaseRadixSortSafeTypes
 Sort both the `vs` and reorder `index` at the same. This allows for faster sortperm
 for radix sort.
 """
-function sorttwo!(vs::AbstractVector{T}, index, lo::Int = 1, hi::Int=length(vs), RADIX_SIZE = 16, RADIX_MASK = 0xffff) where T # <:Union{BaseRadixSortSafeTypes}
+function sorttwo!(vs::AbstractVector{T}, index, lo::Int = 1, hi::Int=length(vs), RADIX_SIZE = 16, RADIX_MASK = 0xffff) where {T<:Union{BaseRadixSortSafeTypes}}
     # Input checking
     if lo >= hi;  return (vs, index);  end
     #println(vs)

--- a/src/sorttwo!.jl
+++ b/src/sorttwo!.jl
@@ -6,7 +6,7 @@ import StatsBase: BaseRadixSortSafeTypes
 Sort both the `vs` and reorder `index` at the same. This allows for faster sortperm
 for radix sort.
 """
-function sorttwo!(vs::AbstractVector{T}, index, lo::Int = 1, hi::Int=length(vs), RADIX_SIZE = 16, RADIX_MASK = 0xffff) where {T<:Union{BaseRadixSortSafeTypes}}
+function sorttwo!(vs::AbstractVector{T}, index, lo::Int = 1, hi::Int=length(vs), RADIX_SIZE = 16, RADIX_MASK = 0xffff) where T<:Union{BaseRadixSortSafeTypes, Missing}
     # Input checking
     if lo >= hi;  return (vs, index);  end
     #println(vs)

--- a/src/sorttwo!.jl
+++ b/src/sorttwo!.jl
@@ -6,7 +6,7 @@ import StatsBase: BaseRadixSortSafeTypes
 Sort both the `vs` and reorder `index` at the same. This allows for faster sortperm
 for radix sort.
 """
-function sorttwo!(vs::Vector{T}, index, lo::Int = 1, hi::Int=length(vs), RADIX_SIZE = 16, RADIX_MASK = 0xffff) where T # <:Union{BaseRadixSortSafeTypes}
+function sorttwo!(vs::AbstractVector{T}, index=1:length(vs), lo::Int = 1, hi::Int=length(vs), RADIX_SIZE = 16, RADIX_MASK = 0xffff) where T # <:Union{BaseRadixSortSafeTypes}
     # Input checking
     if lo >= hi;  return (vs, index);  end
     #println(vs)

--- a/src/uint_hist.jl
+++ b/src/uint_hist.jl
@@ -5,7 +5,7 @@
 Computes a histogram (counts) for the vector RADIX_SIZE bits at a time. E.g. if eltype(bits) is UInt64 and RADIX_SIZE is 16
 then 4 histograms are created for each of the 16 bit chunks.
 """
-function uint_hist(bits::Vector{T}, RADIX_SIZE = 16, RADIX_MASK = 0xffff) where T
+function uint_hist(bits::AbstractVector{T}, RADIX_SIZE = 16, RADIX_MASK = 0xffff) where T
     iter = ceil(Integer, sizeof(T)*8/RADIX_SIZE)
     hist = zeros(UInt32, 2^RADIX_SIZE, iter)
 


### PR DESCRIPTION
Replaces `Vector` with `AbstractVector` in some type annotations, so these methods can be used more broadly.